### PR TITLE
Use JSON format to obtain data from 'ceph -s'

### DIFF
--- a/plugins/ceph/ceph_osd
+++ b/plugins/ceph/ceph_osd
@@ -44,6 +44,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo "osds.value $(ceph -s | grep osdmap | awk '{ print $3 }')"
-echo "up.value $(ceph -s | grep osdmap | awk '{ print $5 }')"
-echo "in.value $(ceph -s | grep osdmap | awk '{ print $7 }')"
+echo "osds.value $(ceph -s --format=json | jq '.osdmap.osdmap.num_osds')"
+echo "up.value $(ceph -s --format=json | jq '.osdmap.osdmap.num_up_osds')"
+echo "in.value $(ceph -s --format=json | jq '.osdmap.osdmap.num_in_osds')"

--- a/plugins/ceph/ceph_osd
+++ b/plugins/ceph/ceph_osd
@@ -44,6 +44,9 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo "osds.value $(ceph -s --format=json | jq '.osdmap.osdmap.num_osds')"
-echo "up.value $(ceph -s --format=json | jq '.osdmap.osdmap.num_up_osds')"
-echo "in.value $(ceph -s --format=json | jq '.osdmap.osdmap.num_in_osds')"
+CEPH_STATUS=$(ceph -s --format=json)
+
+echo "osds.value $(echo $CEPH_STATUS | jq '.osdmap.osdmap.num_osds')"
+echo "up.value $(echo $CEPH_STATUS | jq '.osdmap.osdmap.num_up_osds')"
+echo "in.value $(echo $CEPH_STATUS | jq '.osdmap.osdmap.num_in_osds')"
+


### PR DESCRIPTION
'ceph -s' text output format strongly depends upon ceph version. Using JSON format to obtain data works across different ceph versions.